### PR TITLE
ref: 미들웨어 주입 방식 변경 및 mysql 관련 중복코드 제거

### DIFF
--- a/MiddleWare/recipe.ts
+++ b/MiddleWare/recipe.ts
@@ -2,7 +2,6 @@ import { NextFunction, Request, Response } from "express";
 import * as mysql from "mysql"; //mysql 모듈
 import path from "path";
 import { S3_server } from "../Image_Server/S3_handler";
-import { dbconfig } from "../config/database";
 import {
   AllRecipeJSON,
   FileJSON,
@@ -11,29 +10,15 @@ import {
 } from "../interface";
 import { logs_ } from "../util/botplay";
 import { check_name, check_number } from "../util/checker";
+import { connection } from "../util/mysql";
 
-class _recipe {
+export default class Recipe {
   connection: mysql.Connection;
-  constructor() {
-    this.connection = mysql.createConnection(dbconfig);
-  }
-  handle = () => {
-    this.connection = mysql.createConnection(dbconfig);
-  };
 
-  connectCheck = (req: Request, res: Response, next: NextFunction) => {
-    const self = this;
-    this.connection.on(`error`, function (err: mysql.MysqlError) {
-      if (err.code === `PROTOCOL_CONNECTION_LOST`) {
-        self.handle();
-        next();
-      } else {
-        next();
-      }
-      next();
-    });
-    next();
-  };
+  constructor() {
+    this.connection = connection;
+  }
+
 
   get = (req: Request, res: Response, next: NextFunction) => {
     const seq: string = req.params.seq;
@@ -226,5 +211,3 @@ class _recipe {
     }
   };
 }
-
-export const recipe = new _recipe();

--- a/router/User.ts
+++ b/router/User.ts
@@ -2,29 +2,29 @@ import express from "express";
 
 import { auth } from "../Controller/authetication";
 import { bot_check } from "../MiddleWare/botcheck";
-import { user } from "../MiddleWare/user";
+import User from "../MiddleWare/user";
 
 const router = express.Router();
+const user = new User();
 
+router.get("/users", auth(true), user.getAll); //모든 유저 정보를 가져옴  admin 권한
 
-router.get("/users", user.connectCheck, auth(true), user.getAll); //모든 유저 정보를 가져옴  admin 권한
+router.get("/GetCollection", auth(false), user.getCollection); //아이디 체크
 
-router.get("/GetCollection", user.connectCheck, auth(false), user.getCollection); //아이디 체크
+router.post("/AddCollection/:cId", auth(false), user.addCollection); //컬렉션 추가
 
-router.post("/AddCollection/:cId", user.connectCheck, auth(false), user.addCollection); //컬렉션 추가
+router.post("/Adduser", user.add); //회원 가입
 
-router.post("/Adduser", user.connectCheck, user.add); //회원 가입
-
-router.get("/GetMyInfo", user.connectCheck, auth(false), user.getMyInfo); //자신의 정보 얻어오기
+router.get("/GetMyInfo", auth(false), user.getMyInfo); //자신의 정보 얻어오기
 
 router.get("/check", bot_check); //디코 봇 서버 체크
 
-router.post("/login", user.connectCheck, user.login); //로그인 토큰 반환
+router.post("/login", user.login); //로그인 토큰 반환
 
-router.post("/NewRoom", user.connectCheck, auth(false), user.addNewRoom); //방 만들기
+router.post("/NewRoom", auth(false), user.addNewRoom); //방 만들기
 
-router.get("/myRoom", user.connectCheck, auth(false), user.getMyRoom); //방 가져오기
+router.get("/myRoom", auth(false), user.getMyRoom); //방 가져오기
 
-router.put("/RoomDataChange/:seq", user.connectCheck, auth(false), user.updateRoom); //방 정보 업데이트
+router.put("/RoomDataChange/:seq", auth(false), user.updateRoom); //방 정보 업데이트
 
 export default router;

--- a/router/recipe.ts
+++ b/router/recipe.ts
@@ -1,20 +1,21 @@
-import express from 'express';
-import { auth } from '../Controller/authetication';
-import { upload } from '../Image_Server/storage_handler';
-import { recipe } from '../MiddleWare/recipe';
+import express from "express";
+import { auth } from "../Controller/authetication";
+import { upload } from "../Image_Server/storage_handler";
+import Recipe from "../MiddleWare/recipe";
 
 const router = express.Router();
+const recipe = new Recipe();
 
-router.get("/data/:seq", recipe.connectCheck,recipe.get); //레시피 데이터 
+router.get("/data/:seq", recipe.get); //레시피 데이터
 
-router.post("/Upload",recipe.connectCheck,auth(true),upload.single(`img`), recipe.upload) //레시피 업로드
+router.post("/Upload", auth(true), upload.single(`img`), recipe.upload); //레시피 업로드
 
-router.get("/Search", recipe.connectCheck,recipe.search); //검색
+router.get("/Search", recipe.search); //검색
 
-router.get("/AllData", recipe.connectCheck, recipe.getAll)   //모든 레시피 데이터 가져오기 LIMIT 추가 예정.
+router.get("/AllData", recipe.getAll); //모든 레시피 데이터 가져오기 LIMIT 추가 예정.
 
-router.post("/AddDetail/:recipeName", recipe.connectCheck, auth(true), recipe.addDetail) //상세 설명 추가
+router.post("/AddDetail/:recipeName", auth(true), recipe.addDetail); //상세 설명 추가
 
-router.get("/GetDetail/:recipeName", recipe.connectCheck, recipe.getDetail) //상세 설명 가져오기
+router.get("/GetDetail/:recipeName", recipe.getDetail); //상세 설명 가져오기
 
 export default router;

--- a/util/mysql.ts
+++ b/util/mysql.ts
@@ -1,0 +1,10 @@
+import mysql from "mysql";
+import { dbconfig } from "../config/database";
+
+export let connection = mysql.createConnection(dbconfig);
+
+connection.on("error", (err: mysql.MysqlError) => {
+    if (err.code === "PROTOCOL_CONNECTION_LOST") {
+      connection = mysql.createConnection(dbconfig);
+    }
+});


### PR DESCRIPTION
## 변경 사항
- MiddleWare/user.ts, MiddleWare/recipe.ts에서 class를 export 및 router에서 그 구현체를 생성하도록 변경
- util/mysql.ts에서 mysql connection 객체를 export 해서 MiddleWare 객체에 주입하도록 변경
- util/mysql.ts에서 mysql connection error 핸들러 등록 코드 분리
- router에서 더 이상 핸들러 등록 코드를 호출 하지 않도록 변경
- router/recipe.ts에서의 moment import 방식 변경

issue: #5