### PR TITLE
ref: mysql의 연결이 끊어지면 resume()을 사용하도록 변경

### DIFF
--- a/util/mysql.ts
+++ b/util/mysql.ts
@@ -1,10 +1,10 @@
-import mysql from "mysql";
+import { createConnection, MysqlError } from "mysql";
 import { dbconfig } from "../config/database";
 
-export let connection = mysql.createConnection(dbconfig);
+export const connection = createConnection(dbconfig);
 
-connection.on("error", (err: mysql.MysqlError) => {
-    if (err.code === "PROTOCOL_CONNECTION_LOST") {
-      connection = mysql.createConnection(dbconfig);
-    }
+connection.on("error", (err: MysqlError) => {
+  if (err.code === "PROTOCOL_CONNECTION_LOST") {
+    connection.resume();
+  }
 });


### PR DESCRIPTION
## 변경 사항
- mysql.createConnection() 대신 Connection.resume()을 사용하도록 변경하였습니다.
- connection 객체를 const로 변경하였습니다.
- 필요한 객체만 import 하도록 변경하였습니다.

issue: #21