### PR TITLE
ref: 엔드포인트 URI 변경

### DIFF
--- a/router/User.ts
+++ b/router/User.ts
@@ -7,22 +7,18 @@ import { Role } from "../types/enum";
 const router = Router();
 const user = new User();
 
-router.get("/users", auth(Role.Admin), user.getAll); //모든 유저 정보를 가져옴  admin 권한
-
-router.get("/GetCollection", auth(Role.User), user.getCollection); //아이디 체크
-
-router.post("/AddCollection/:cId", auth(Role.User), user.addCollection); //컬렉션 추가
-
-router.post("/Adduser", user.add); //회원 가입
-
-router.get("/GetMyInfo", auth(Role.User), user.getMyInfo); //자신의 정보 얻어오기
-
 router.post("/login", user.login); //로그인 토큰 반환
 
-router.post("/NewRoom", auth(Role.User), user.addNewRoom); //방 만들기
+router.get("/collections/my", auth(Role.User), user.getCollection); //아이디 체크
+router.post("/collections/my/:cId", auth(Role.User), user.addCollection); //컬렉션 추가
 
-router.get("/myRoom", auth(Role.User), user.getMyRoom); //방 가져오기
+router.get("/users", auth(Role.Admin), user.getAll); //모든 유저 정보를 가져옴  admin 권한
+router.get("/users/my", auth(Role.User), user.getMyInfo); //자신의 정보 얻어오기
+router.get("/users/:uId", auth(Role.Admin), user.get)
+router.post("/users", user.add); //회원 가입
 
-router.put("/RoomDataChange/:seq", auth(Role.User), user.updateRoom); //방 정보 업데이트
+router.get("/rooms/my", auth(Role.User), user.getMyRoom); //방 가져오기
+router.post("/rooms", auth(Role.User), user.addNewRoom); //방 만들기
+router.put("/rooms/my/:seq", auth(Role.User), user.updateRoom); //방 정보 업데이트
 
 export default router;

--- a/router/main.ts
+++ b/router/main.ts
@@ -6,9 +6,9 @@ import RecipeRouter from "./recipe";
 
 const router = Router();
 
-router.use("/User", UserRouter); //유저 관련 라우터
+router.use(UserRouter); //유저 관련 라우터
 
-router.use("/rec", RecipeRouter); //레시피 관련 라우터
+router.use(RecipeRouter); //레시피 관련 라우터
 
 router.get("/privacy", cache("60 minutes"), privacy); //개인정보 취급 방침
 

--- a/router/recipe.ts
+++ b/router/recipe.ts
@@ -9,16 +9,16 @@ import { Role } from "../types/enum";
 const router = Router();
 const recipe = new Recipe();
 
-router.get("/data/:seq", recipe.get); //레시피 데이터
 
-router.post("/Upload", auth(Role.Admin), uploadImg, recipe.upload); //레시피 업로드
 
-router.get("/Search", recipe.search); //검색
 
-router.get("/AllData", recipe.getAll); //모든 레시피 데이터 가져오기 LIMIT 추가 예정.
+router.get("/recipes", recipe.getAll); //모든 레시피 데이터 가져오기 LIMIT 추가 예정.
+router.get("/recipes/:seq", recipe.get); //레시피 데이터
+router.post("/recipes", auth(Role.Admin), uploadImg, recipe.upload); //레시피 업로드
+router.get("/recipes/search", recipe.search); //검색
 
-router.post("/AddDetail/:recipeName", auth(Role.Admin), recipe.addDetail); //상세 설명 추가
+router.get("/recipes/details/:recipeName", recipe.getDetail); //상세 설명 가져오기
+router.post("/recipes/details/:recipeName", auth(Role.Admin), recipe.addDetail); //상세 설명 추가
 
-router.get("/GetDetail/:recipeName", recipe.getDetail); //상세 설명 가져오기
 
 export default router;


### PR DESCRIPTION
## 변경 사항
- 라우터별로 해당 엔드포인트 URI를 한눈에 확인할 수 있도록 main.ts에서 라우터별 root 경로를 지정하지 않도록 변경했습니다.
- 자원을 나타내는 복수 명사를 사용하도록 변경했습니다.(recipes, users, collections, rooms, details 등)
- CRUD를 나타내는 명칭을 사용하지 않도록 변경했습니다.
- 단일 자원을 얻는 엔드포인트의 URI는 집합 자원을 얻는 엔드포인트에 router parameter를 추가하는 형태로 변경했습니다.

issue: #3