### PR TITLE
fix: MiddleWare/upload.ts에서 arrow 함수 없이 export하도록 변경

### DIFF
--- a/MiddleWare/upload.ts
+++ b/MiddleWare/upload.ts
@@ -25,4 +25,4 @@ const upload: multer.Multer = multer(
   }
 );
 
-export const uploadImg = () => upload.single("img");
+export const uploadImg = upload.single("img");


### PR DESCRIPTION
## 변경 사항
- upload.ts에서 upload.single("img") 자체를 export하도록 변경합니다.

issue: #27